### PR TITLE
HP-84: Support for giving rewards in multiple tokens

### DIFF
--- a/contracts/hyphen/LiquidityFarming.sol
+++ b/contracts/hyphen/LiquidityFarming.sol
@@ -383,7 +383,7 @@ contract HyphenLiquidityFarming is
         return rewardRateLog[_baseToken][rewardRateLog[_baseToken].length - 1].rewardsPerSecond;
     }
 
-    function migrateNftsToV2(uint256[] memory _nftIds, IHyphenLiquidityFarmingV2 _farmingV2) external {
+    function migrateNftsToV2(uint256[] calldata _nftIds, IHyphenLiquidityFarmingV2 _farmingV2) external {
         uint256 length = _nftIds.length;
         address payable msgSender = payable(_msgSender());
 

--- a/contracts/hyphen/LiquidityFarmingV2.sol
+++ b/contracts/hyphen/LiquidityFarmingV2.sol
@@ -19,14 +19,14 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./metatx/ERC2771ContextUpgradeable.sol";
-import "./interfaces/IHyphenLiquidityFarmingV2.sol";
 
 import "../security/Pausable.sol";
 import "./interfaces/ILPToken.sol";
 import "./interfaces/ILiquidityProviders.sol";
 
-contract HyphenLiquidityFarming is
+contract HyphenLiquidityFarmingV2 is
     Initializable,
     ERC2771ContextUpgradeable,
     OwnableUpgradeable,
@@ -35,15 +35,21 @@ contract HyphenLiquidityFarming is
     IERC721ReceiverUpgradeable
 {
     using SafeERC20Upgradeable for IERC20Upgradeable;
+    using EnumerableSet for EnumerableSet.AddressSet;
 
     ILPToken public lpToken;
     ILiquidityProviders public liquidityProviders;
 
-    struct NFTInfo {
-        address payable staker;
+    struct RewardInfo {
         uint256 rewardDebt;
         uint256 unpaidRewards;
+    }
+
+    struct NFTInfo {
+        address payable staker;
         bool isStaked;
+        // Reward Token -> Reward Info
+        mapping(address => RewardInfo) rewardInfo;
     }
 
     struct PoolInfo {
@@ -56,36 +62,40 @@ contract HyphenLiquidityFarming is
         uint256 timestamp;
     }
 
-    /// @notice Mapping to track the rewarder pool.
-    mapping(address => PoolInfo) public poolInfo;
+    /// @notice Mapping to track the rewarder pool. baseToken -> rewardToken -> poolInfo
+    mapping(address => mapping(address => PoolInfo)) public poolInfo;
 
     /// @notice Info of each NFT that is staked.
     mapping(uint256 => NFTInfo) public nftInfo;
 
-    /// @notice Reward Token
-    mapping(address => address) public rewardTokens;
+    // Reward Tokens. Base Token -> Array of Reward Tokens
+    mapping(address => EnumerableSet.AddressSet) internal rewardTokens;
 
     /// @notice Staker => NFTs staked
     mapping(address => uint256[]) public nftIdsStaked;
 
-    /// @notice Token => Total Shares Staked
+    /// @notice Base Token => Total Shares Staked
     mapping(address => uint256) public totalSharesStaked;
 
-    /// @notice Token => Reward Rate Updation history
-    mapping(address => RewardsPerSecondEntry[]) public rewardRateLog;
+    /// @notice Token => Reward Rate Updation history. baseToken -> rewardToken -> rewardsPerSecondEntry
+    mapping(address => mapping(address => RewardsPerSecondEntry[])) public rewardRateLog;
 
     uint256 private constant ACC_TOKEN_PRECISION = 1e12;
     address internal constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     event LogDeposit(address indexed user, address indexed baseToken, uint256 nftId);
     event LogWithdraw(address indexed user, address baseToken, uint256 nftId, address indexed to);
-    event LogOnReward(address indexed user, address indexed baseToken, uint256 amount, address indexed to);
+    event LogOnReward(
+        address indexed user,
+        address indexed baseToken,
+        address indexed rewardToken,
+        uint256 amount,
+        address to
+    );
     event LogUpdatePool(address indexed baseToken, uint256 lastRewardTime, uint256 lpSupply, uint256 accToken1PerShare);
-    event LogRewardPerSecond(address indexed baseToken, uint256 rewardPerSecond);
-    event LogRewardPoolInitialized(address _baseToken, address _rewardToken, uint256 _rewardPerSecond);
+    event LogRewardPerSecond(address indexed baseToken, address indexed rewardToken, uint256 indexed rewardPerSecond);
     event LogNativeReceived(address indexed sender, uint256 value);
     event LiquidityProviderUpdated(address indexed liquidityProviders);
-    event LogNftMigrated(address indexed owner, uint256 indexed nftId, IHyphenLiquidityFarmingV2 farmingContract);
 
     function initialize(
         address _trustedForwarder,
@@ -105,21 +115,34 @@ contract HyphenLiquidityFarming is
         _setTrustedForwarder(_tf);
     }
 
-    /// @notice Initialize the rewarder pool.
-    /// @param _baseToken Base token to be used for the rewarder pool.
-    /// @param _rewardToken Reward token to be used for the rewarder pool.
-    /// @param _rewardPerSecond Reward rate per base token.
-    function initalizeRewardPool(
+    /// @notice Sets the sushi per second to be distributed. Can only be called by the owner.
+    /// @param _rewardPerSecond The amount of Sushi to be distributed per second.
+    function setRewardPerSecond(
         address _baseToken,
         address _rewardToken,
         uint256 _rewardPerSecond
     ) external onlyOwner {
-        require(rewardTokens[_baseToken] == address(0), "ERR__POOL_ALREADY_INITIALIZED");
+        require(_rewardPerSecond <= 10**40, "ERR__REWARD_PER_SECOND_TOO_HIGH");
         require(_baseToken != address(0), "ERR__BASE_TOKEN_IS_ZERO");
         require(_rewardToken != address(0), "ERR_REWARD_TOKEN_IS_ZERO");
-        rewardTokens[_baseToken] = _rewardToken;
-        rewardRateLog[_baseToken].push(RewardsPerSecondEntry(_rewardPerSecond, block.timestamp));
-        emit LogRewardPoolInitialized(_baseToken, _rewardToken, _rewardPerSecond);
+
+        if (!rewardTokens[_baseToken].contains(_rewardToken)) {
+            rewardTokens[_baseToken].add(_rewardToken);
+        }
+        rewardRateLog[_baseToken][_rewardToken].push(RewardsPerSecondEntry(_rewardPerSecond, block.timestamp));
+
+        emit LogRewardPerSecond(_baseToken, _rewardToken, _rewardPerSecond);
+    }
+
+    function getRewardTokens(address _baseToken) external view returns (address[] memory) {
+        uint256 length = rewardTokens[_baseToken].length();
+        address[] memory tokens = new address[](length);
+        unchecked {
+            for (uint256 i = 0; i < length; ++i) {
+                tokens[i] = rewardTokens[_baseToken].at(i);
+            }
+        }
+        return tokens;
     }
 
     function updateLiquidityProvider(ILiquidityProviders _liquidityProviders) external onlyOwner {
@@ -140,58 +163,64 @@ contract HyphenLiquidityFarming is
 
     /// @notice Update the reward state of a nft, and if possible send reward funds to _to.
     /// @param _nftId NFT ID that is being locked
+    /// @param _rewardToken Reward Token to be used for the reward
     /// @param _to Address to which rewards will be credited.
-    function _sendRewardsForNft(uint256 _nftId, address payable _to) internal {
+    function _sendRewardsForNft(
+        uint256 _nftId,
+        address _rewardToken,
+        address payable _to
+    ) internal {
         NFTInfo storage nft = nftInfo[_nftId];
         require(nft.isStaked, "ERR__NFT_NOT_STAKED");
 
         (address baseToken, , uint256 amount) = lpToken.tokenMetadata(_nftId);
         amount /= liquidityProviders.BASE_DIVISOR();
 
-        PoolInfo memory pool = updatePool(baseToken);
+        require(rewardTokens[baseToken].contains(_rewardToken), "ERR__REWARD_TOKEN_NOT_SUPPORTED");
+
+        PoolInfo memory pool = _updateRewardTokenParameters(baseToken, _rewardToken);
         uint256 pending;
         uint256 amountSent;
+        RewardInfo storage rewardInfo = nft.rewardInfo[_rewardToken];
+
         if (amount > 0) {
-            pending = ((amount * pool.accTokenPerShare) / ACC_TOKEN_PRECISION) - nft.rewardDebt + nft.unpaidRewards;
-            if (rewardTokens[baseToken] == NATIVE) {
+            pending =
+                ((amount * pool.accTokenPerShare) / ACC_TOKEN_PRECISION) -
+                rewardInfo.rewardDebt +
+                rewardInfo.unpaidRewards;
+            if (_rewardToken == NATIVE) {
                 uint256 balance = address(this).balance;
                 if (pending > balance) {
                     unchecked {
-                        nft.unpaidRewards = pending - balance;
+                        rewardInfo.unpaidRewards = pending - balance;
                     }
                     (bool success, ) = _to.call{value: balance}("");
                     require(success, "ERR__NATIVE_TRANSFER_FAILED");
                     amountSent = balance;
                 } else {
-                    nft.unpaidRewards = 0;
+                    rewardInfo.unpaidRewards = 0;
                     (bool success, ) = _to.call{value: pending}("");
                     require(success, "ERR__NATIVE_TRANSFER_FAILED");
                     amountSent = pending;
                 }
             } else {
-                IERC20Upgradeable rewardToken = IERC20Upgradeable(rewardTokens[baseToken]);
+                IERC20Upgradeable rewardToken = IERC20Upgradeable(_rewardToken);
                 uint256 balance = rewardToken.balanceOf(address(this));
                 if (pending > balance) {
                     unchecked {
-                        nft.unpaidRewards = pending - balance;
+                        rewardInfo.unpaidRewards = pending - balance;
                     }
                     amountSent = _sendErc20AndGetSentAmount(rewardToken, balance, _to);
                 } else {
-                    nft.unpaidRewards = 0;
+                    rewardInfo.unpaidRewards = 0;
                     amountSent = _sendErc20AndGetSentAmount(rewardToken, pending, _to);
                 }
             }
         }
-        nft.rewardDebt = (amount * pool.accTokenPerShare) / ACC_TOKEN_PRECISION;
-        emit LogOnReward(_msgSender(), baseToken, amountSent, _to);
-    }
 
-    /// @notice Sets the sushi per second to be distributed. Can only be called by the owner.
-    /// @param _rewardPerSecond The amount of Sushi to be distributed per second.
-    function setRewardPerSecond(address _baseToken, uint256 _rewardPerSecond) external onlyOwner {
-        require(_rewardPerSecond <= 10**40, "ERR__REWARD_PER_SECOND_TOO_HIGH");
-        rewardRateLog[_baseToken].push(RewardsPerSecondEntry(_rewardPerSecond, block.timestamp));
-        emit LogRewardPerSecond(_baseToken, _rewardPerSecond);
+        rewardInfo.rewardDebt = (amount * pool.accTokenPerShare) / ACC_TOKEN_PRECISION;
+
+        emit LogOnReward(_msgSender(), baseToken, _rewardToken, amountSent, _to);
     }
 
     /// @notice Allows owner to reclaim/withdraw any tokens (including reward tokens) held by this contract
@@ -227,33 +256,32 @@ contract HyphenLiquidityFarming is
         );
 
         NFTInfo storage nft = nftInfo[_nftId];
+
         require(!nft.isStaked, "ERR__NFT_ALREADY_STAKED");
+        nft.isStaked = true;
+        nft.staker = _to;
 
         (address baseToken, , uint256 amount) = lpToken.tokenMetadata(_nftId);
         amount /= liquidityProviders.BASE_DIVISOR();
 
-        require(rewardTokens[baseToken] != address(0), "ERR__POOL_NOT_INITIALIZED");
-        require(rewardRateLog[baseToken].length != 0, "ERR__POOL_NOT_INITIALIZED");
-
         lpToken.safeTransferFrom(msgSender, address(this), _nftId);
 
-        PoolInfo memory pool = updatePool(baseToken);
-        nft.isStaked = true;
-        nft.staker = _to;
-        nft.rewardDebt = (amount * pool.accTokenPerShare) / ACC_TOKEN_PRECISION;
+        uint256 totalRewardTokens = rewardTokens[baseToken].length();
+        require(totalRewardTokens != 0, "ERR__POOL_NOT_INITIALIZED");
+
+        for (uint256 i = 0; i < totalRewardTokens; ) {
+            address rewardToken = rewardTokens[baseToken].at(i);
+            PoolInfo memory pool = _updateRewardTokenParameters(baseToken, rewardToken);
+            nft.rewardInfo[rewardToken].rewardDebt = (amount * pool.accTokenPerShare) / ACC_TOKEN_PRECISION;
+            unchecked {
+                ++i;
+            }
+        }
 
         nftIdsStaked[_to].push(_nftId);
         totalSharesStaked[baseToken] += amount;
 
         emit LogDeposit(msgSender, baseToken, _nftId);
-    }
-
-    /// @notice Withdraw LP tokens
-    /// @param _nftId LP token nftId to withdraw.
-    /// @param _to The receiver of `amount` withdraw benefit.
-    function withdraw(uint256 _nftId, address payable _to) external whenNotPaused nonReentrant {
-        uint256 index = getStakedNftIndex(_msgSender(), _nftId);
-        _withdraw(_nftId, _to, index);
     }
 
     function getStakedNftIndex(address _staker, uint256 _nftId) public view returns (uint256) {
@@ -278,15 +306,23 @@ contract HyphenLiquidityFarming is
 
         require(nftIdsStaked[msgSender][_index] == _nftId, "ERR__NOT_OWNER");
         require(nftInfo[_nftId].staker == msgSender, "ERR__NOT_OWNER");
-        require(nftInfo[_nftId].unpaidRewards == 0, "ERR__UNPAID_REWARDS_EXIST");
 
         nftIdsStaked[msgSender][_index] = nftIdsStaked[msgSender][nftIdsStaked[msgSender].length - 1];
         nftIdsStaked[msgSender].pop();
 
-        _sendRewardsForNft(_nftId, _to);
+        (address baseToken, , uint256 amount) = lpToken.tokenMetadata(_nftId);
+        uint256 totalRewardTokens = rewardTokens[baseToken].length();
+
+        for (uint256 i = 0; i < totalRewardTokens; ) {
+            address rewardToken = rewardTokens[baseToken].at(i);
+            _sendRewardsForNft(_nftId, rewardToken, _to);
+            require(nftInfo[_nftId].rewardInfo[rewardToken].unpaidRewards == 0, "ERR__UNPAID_REWARDS_EXIST");
+            unchecked {
+                ++i;
+            }
+        }
         delete nftInfo[_nftId];
 
-        (address baseToken, , uint256 amount) = lpToken.tokenMetadata(_nftId);
         amount /= liquidityProviders.BASE_DIVISOR();
         totalSharesStaked[baseToken] -= amount;
 
@@ -295,7 +331,7 @@ contract HyphenLiquidityFarming is
         emit LogWithdraw(msgSender, baseToken, _nftId, _to);
     }
 
-    function withdrawV2(
+    function withdrawAtIndex(
         uint256 _nftId,
         address payable _to,
         uint256 _index
@@ -303,31 +339,57 @@ contract HyphenLiquidityFarming is
         _withdraw(_nftId, _to, _index);
     }
 
+    /// @notice Withdraw LP tokens
+    /// @param _nftId LP token nftId to withdraw.
+    /// @param _to The receiver of `amount` withdraw benefit.
+    function withdraw(uint256 _nftId, address payable _to) external whenNotPaused nonReentrant {
+        uint256 index = getStakedNftIndex(_msgSender(), _nftId);
+        _withdraw(_nftId, _to, index);
+    }
+
     /// @notice Extract all rewards without withdrawing LP tokens
     /// @param _nftId LP token nftId for which rewards are to be withdrawn
     /// @param _to The receiver of withdraw benefit.
-    function extractRewards(uint256 _nftId, address payable _to) external whenNotPaused nonReentrant {
+    function extractRewards(
+        uint256 _nftId,
+        address[] memory _rewardTokens,
+        address payable _to
+    ) external whenNotPaused nonReentrant {
         require(nftInfo[_nftId].staker == _msgSender(), "ERR__NOT_OWNER");
-        _sendRewardsForNft(_nftId, _to);
+
+        uint256 length = _rewardTokens.length;
+        require(length > 0, "ERR__NO_REWARD_TOKENS");
+
+        for (uint256 i = 0; i < length; ) {
+            address rewardToken = _rewardTokens[i];
+            _sendRewardsForNft(_nftId, rewardToken, _to);
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     /// @notice Calculates an up to date value of accTokenPerShare
     /// @notice An updated value of accTokenPerShare is comitted to storage every time a new NFT is deposited, withdrawn or rewards are extracted
-    function getUpdatedAccTokenPerShare(address _baseToken) public view returns (uint256) {
+    function getUpdatedAccTokenPerShare(address _baseToken, address _rewardToken) public view returns (uint256) {
+        PoolInfo memory pool = poolInfo[_baseToken][_rewardToken];
+        RewardsPerSecondEntry[] memory logs = rewardRateLog[_baseToken][_rewardToken];
+        require(logs.length > 0, "ERR__NO_REWARD_RATE_LOGS");
+
         uint256 accumulator = 0;
-        uint256 lastUpdatedTime = poolInfo[_baseToken].lastRewardTime;
+        uint256 lastUpdatedTime = pool.lastRewardTime;
         uint256 counter = block.timestamp;
-        uint256 i = rewardRateLog[_baseToken].length - 1;
+        uint256 i = logs.length - 1;
+
         while (true) {
             if (lastUpdatedTime >= counter) {
                 break;
             }
+            RewardsPerSecondEntry memory log = logs[i];
             unchecked {
-                accumulator +=
-                    rewardRateLog[_baseToken][i].rewardsPerSecond *
-                    (counter - max(lastUpdatedTime, rewardRateLog[_baseToken][i].timestamp));
+                accumulator += log.rewardsPerSecond * (counter - max(lastUpdatedTime, log.timestamp));
             }
-            counter = rewardRateLog[_baseToken][i].timestamp;
+            counter = log.timestamp;
             if (i == 0) {
                 break;
             }
@@ -338,13 +400,14 @@ contract HyphenLiquidityFarming is
         // the value of totalSharesStaked[_baseToken] would not have changed, as we only consider the
         // updates to the pool that happened after the lastUpdatedTime.
         accumulator = (accumulator * ACC_TOKEN_PRECISION) / totalSharesStaked[_baseToken];
-        return accumulator + poolInfo[_baseToken].accTokenPerShare;
+        return accumulator + pool.accTokenPerShare;
     }
 
     /// @notice View function to see pending Token
     /// @param _nftId NFT for which pending tokens are to be viewed
+    /// @param _rewardToken reward token for which pending tokens are to be viewed
     /// @return pending reward for a given user.
-    function pendingToken(uint256 _nftId) external view returns (uint256) {
+    function pendingToken(uint256 _nftId, address _rewardToken) external view returns (uint256) {
         NFTInfo storage nft = nftInfo[_nftId];
         if (!nft.isStaked) {
             return 0;
@@ -353,23 +416,34 @@ contract HyphenLiquidityFarming is
         (address baseToken, , uint256 amount) = lpToken.tokenMetadata(_nftId);
         amount /= liquidityProviders.BASE_DIVISOR();
 
-        PoolInfo memory pool = poolInfo[baseToken];
+        if(!rewardTokens[baseToken].contains(_rewardToken)) {
+            return 0;
+        }
+
+        PoolInfo memory pool = poolInfo[baseToken][_rewardToken];
         uint256 accToken1PerShare = pool.accTokenPerShare;
         if (block.timestamp > pool.lastRewardTime && totalSharesStaked[baseToken] != 0) {
-            accToken1PerShare = getUpdatedAccTokenPerShare(baseToken);
+            accToken1PerShare = getUpdatedAccTokenPerShare(baseToken, _rewardToken);
         }
-        return ((amount * accToken1PerShare) / ACC_TOKEN_PRECISION) - nft.rewardDebt + nft.unpaidRewards;
+        return
+            ((amount * accToken1PerShare) / ACC_TOKEN_PRECISION) -
+            nft.rewardInfo[_rewardToken].rewardDebt +
+            nft.rewardInfo[_rewardToken].unpaidRewards;
     }
 
     /// @notice Update reward variables of the given pool.
     /// @return pool Returns the pool that was updated.
-    function updatePool(address _baseToken) public whenNotPaused returns (PoolInfo memory pool) {
-        pool = poolInfo[_baseToken];
+    function _updateRewardTokenParameters(address _baseToken, address _rewardToken)
+        internal
+        whenNotPaused
+        returns (PoolInfo memory pool)
+    {
+        pool = poolInfo[_baseToken][_rewardToken];
         if (totalSharesStaked[_baseToken] > 0) {
-            pool.accTokenPerShare = getUpdatedAccTokenPerShare(_baseToken);
+            pool.accTokenPerShare = getUpdatedAccTokenPerShare(_baseToken, _rewardToken);
         }
         pool.lastRewardTime = block.timestamp;
-        poolInfo[_baseToken] = pool;
+        poolInfo[_baseToken][_rewardToken] = pool;
         emit LogUpdatePool(_baseToken, pool.lastRewardTime, totalSharesStaked[_baseToken], pool.accTokenPerShare);
     }
 
@@ -379,42 +453,12 @@ contract HyphenLiquidityFarming is
         nftIds = nftIdsStaked[_user];
     }
 
-    function getRewardRatePerSecond(address _baseToken) external view returns (uint256) {
-        return rewardRateLog[_baseToken][rewardRateLog[_baseToken].length - 1].rewardsPerSecond;
-    }
-
-    function migrateNftsToV2(uint256[] memory _nftIds, IHyphenLiquidityFarmingV2 _farmingV2) external {
-        uint256 length = _nftIds.length;
-        address payable msgSender = payable(_msgSender());
-
-        for (uint256 i = 0; i < length; ) {
-            uint256 nftId = _nftIds[i];
-            uint256 index = getStakedNftIndex(_msgSender(), nftId);
-
-            require(nftIdsStaked[msgSender][index] == nftId, "ERR__NOT_OWNER");
-            require(nftInfo[nftId].staker == msgSender, "ERR__NOT_OWNER");
-
-            nftIdsStaked[msgSender][index] = nftIdsStaked[msgSender][nftIdsStaked[msgSender].length - 1];
-            nftIdsStaked[msgSender].pop();
-
-            _sendRewardsForNft(nftId, msgSender);
-
-            require(nftInfo[nftId].unpaidRewards == 0, "ERR__UNPAID_REWARDS_EXIST");
-            delete nftInfo[nftId];
-
-            (address baseToken, , uint256 amount) = lpToken.tokenMetadata(nftId);
-            amount /= liquidityProviders.BASE_DIVISOR();
-            totalSharesStaked[baseToken] -= amount;
-
-            lpToken.approve(address(_farmingV2), nftId);
-            _farmingV2.deposit(nftId, msgSender);
-
-            emit LogNftMigrated(msgSender, nftId, _farmingV2);
-
-            unchecked {
-                ++i;
-            }
+    function getRewardRatePerSecond(address _baseToken, address _rewardToken) external view returns (uint256) {
+        uint256 length = rewardRateLog[_baseToken][_rewardToken].length;
+        if (length == 0) {
+            return 0;
         }
+        return rewardRateLog[_baseToken][_rewardToken][length - 1].rewardsPerSecond;
     }
 
     function onERC721Received(
@@ -423,7 +467,7 @@ contract HyphenLiquidityFarming is
         uint256,
         bytes calldata
     ) external pure override(IERC721ReceiverUpgradeable) returns (bytes4) {
-        return bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"));
+        return this.onERC721Received.selector;
     }
 
     function _msgSender()

--- a/contracts/hyphen/LiquidityFarmingV2.sol
+++ b/contracts/hyphen/LiquidityFarmingV2.sol
@@ -352,7 +352,7 @@ contract HyphenLiquidityFarmingV2 is
     /// @param _to The receiver of withdraw benefit.
     function extractRewards(
         uint256 _nftId,
-        address[] memory _rewardTokens,
+        address[] calldata _rewardTokens,
         address payable _to
     ) external whenNotPaused nonReentrant {
         require(nftInfo[_nftId].staker == _msgSender(), "ERR__NOT_OWNER");

--- a/contracts/hyphen/interfaces/IHyphenLiquidityFarmingV2.sol
+++ b/contracts/hyphen/interfaces/IHyphenLiquidityFarmingV2.sol
@@ -1,0 +1,97 @@
+interface IHyphenLiquidityFarmingV2 {
+    function changePauser(address newPauser) external;
+
+    function deposit(uint256 _nftId, address _to) external;
+
+    function extractRewards(
+        uint256 _nftId,
+        address[] memory _rewardTokens,
+        address _to
+    ) external;
+
+    function getNftIdsStaked(address _user) external view returns (uint256[] memory nftIds);
+
+    function getRewardRatePerSecond(address _baseToken, address _rewardToken) external view returns (uint256);
+
+    function getRewardTokens(address _baseToken) external view returns (address[] memory);
+
+    function getStakedNftIndex(address _staker, uint256 _nftId) external view returns (uint256);
+
+    function getUpdatedAccTokenPerShare(address _baseToken, address _rewardToken) external view returns (uint256);
+
+    function initialize(
+        address _trustedForwarder,
+        address _pauser,
+        address _liquidityProviders,
+        address _lpToken
+    ) external;
+
+    function isPauser(address pauser) external view returns (bool);
+
+    function isTrustedForwarder(address forwarder) external view returns (bool);
+
+    function liquidityProviders() external view returns (address);
+
+    function lpToken() external view returns (address);
+
+    function nftIdsStaked(address, uint256) external view returns (uint256);
+
+    function nftInfo(uint256) external view returns (address staker, bool isStaked);
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes memory
+    ) external pure returns (bytes4);
+
+    function owner() external view returns (address);
+
+    function pause() external;
+
+    function paused() external view returns (bool);
+
+    function pendingToken(uint256 _nftId, address _rewardToken) external view returns (uint256);
+
+    function poolInfo(address, address) external view returns (uint256 accTokenPerShare, uint256 lastRewardTime);
+
+    function reclaimTokens(
+        address _token,
+        uint256 _amount,
+        address _to
+    ) external;
+
+    function renounceOwnership() external;
+
+    function renouncePauser() external;
+
+    function rewardRateLog(
+        address,
+        address,
+        uint256
+    ) external view returns (uint256 rewardsPerSecond, uint256 timestamp);
+
+    function setRewardPerSecond(
+        address _baseToken,
+        address _rewardToken,
+        uint256 _rewardPerSecond
+    ) external;
+
+    function setTrustedForwarder(address _tf) external;
+
+    function totalSharesStaked(address) external view returns (uint256);
+
+    function transferOwnership(address newOwner) external;
+
+    function unpause() external;
+
+    function updateLiquidityProvider(address _liquidityProviders) external;
+
+    function withdraw(uint256 _nftId, address _to) external;
+
+    function withdrawAtIndex(
+        uint256 _nftId,
+        address _to,
+        uint256 _index
+    ) external;
+}

--- a/scripts/token-manager/deploy-fuji.ts
+++ b/scripts/token-manager/deploy-fuji.ts
@@ -1,0 +1,60 @@
+import { ethers } from "hardhat";
+import { parseUnits } from "ethers/lib/utils";
+import { deploy, IDeployConfig } from "./helper";
+
+(async () => {
+  const config: IDeployConfig = {
+    trustedForwarder: "0x6271Ca63D30507f2Dcbf99B52787032506D75BBF",
+    bicoOwner: "0x46b65ae065341D034fEA45D76c6fA936EAfBfdeb",
+    pauser: "0x46b65ae065341D034fEA45D76c6fA936EAfBfdeb",
+    tokens: [
+      {
+        tokenAddress: "0xB4E0F6FEF81BdFea0856bB846789985c9CFf7e85",
+        minCap: ethers.BigNumber.from(10).pow(18 + 2),
+        maxCap: ethers.BigNumber.from(10).pow(18 + 4),
+        depositConfigs: [
+          {
+            chainId: 5,
+            minCap: ethers.BigNumber.from(10).pow(18 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(18 + 3)),
+          },
+          {
+            chainId: 80001,
+            minCap: ethers.BigNumber.from(10).pow(18 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(18 + 3)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+      {
+        tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        minCap: ethers.BigNumber.from(10).pow(18 - 2),
+        maxCap: ethers.BigNumber.from(10).pow(18 + 2),
+        depositConfigs: [
+          {
+            chainId: 80001,
+            minCap: ethers.BigNumber.from(10).pow(18 - 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(97).mul(ethers.BigNumber.from(10).pow(18)),
+          },
+          {
+            chainId: 5,
+            minCap: ethers.BigNumber.from(10).pow(18 - 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(97).mul(ethers.BigNumber.from(10).pow(18)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+    ],
+  };
+  await deploy(config);
+})();

--- a/scripts/token-manager/deploy-goerli.ts
+++ b/scripts/token-manager/deploy-goerli.ts
@@ -1,0 +1,77 @@
+import { ethers } from "hardhat";
+import { parseUnits } from "ethers/lib/utils";
+import { deploy, IDeployConfig } from "./helper";
+
+(async () => {
+  const config: IDeployConfig = {
+    trustedForwarder: "0xE041608922d06a4F26C0d4c27d8bCD01daf1f792",
+    bicoOwner: "0x46b65ae065341D034fEA45D76c6fA936EAfBfdeb",
+    pauser: "0x46b65ae065341D034fEA45D76c6fA936EAfBfdeb",
+    tokens: [
+      {
+        tokenAddress: "0x64ef393b6846114bad71e2cb2ccc3e10736b5716",
+        minCap: ethers.BigNumber.from(10).pow(18 + 2),
+        maxCap: ethers.BigNumber.from(10).pow(18 + 4),
+        depositConfigs: [
+          {
+            chainId: 43113,
+            minCap: ethers.BigNumber.from(10).pow(18 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(18 + 3)),
+          },
+          {
+            chainId: 80001,
+            minCap: ethers.BigNumber.from(10).pow(18 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(18 + 3)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+      {
+        tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        minCap: ethers.BigNumber.from(10).pow(18 - 2),
+        maxCap: ethers.BigNumber.from(10).pow(18 + 2),
+        depositConfigs: [
+          {
+            chainId: 43113,
+            minCap: ethers.BigNumber.from(10).pow(18 - 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(97).mul(ethers.BigNumber.from(10).pow(18)),
+          },
+          {
+            chainId: 80001,
+            minCap: ethers.BigNumber.from(10).pow(18 - 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(97).mul(ethers.BigNumber.from(10).pow(18)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+      {
+        tokenAddress: "0xb5B640E6414b6DeF4FC9B3C1EeF373925effeCcF",
+        minCap: ethers.BigNumber.from(10).pow(6 + 2),
+        maxCap: ethers.BigNumber.from(10).pow(6 + 4),
+        depositConfigs: [
+          {
+            chainId: 80001,
+            minCap: ethers.BigNumber.from(10).pow(6 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(6 + 3)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+    ],
+  };
+  await deploy(config);
+})();

--- a/scripts/token-manager/deploy-mumbai.ts
+++ b/scripts/token-manager/deploy-mumbai.ts
@@ -1,0 +1,77 @@
+import { ethers } from "hardhat";
+import { deploy, IDeployConfig } from "./helper";
+import { parseUnits } from "ethers/lib/utils";
+
+(async () => {
+  const config: IDeployConfig = {
+    trustedForwarder: "0x9399BB24DBB5C4b782C70c2969F58716Ebbd6a3b",
+    bicoOwner: "0x46b65ae065341D034fEA45D76c6fA936EAfBfdeb",
+    pauser: "0x46b65ae065341D034fEA45D76c6fA936EAfBfdeb",
+    tokens: [
+      {
+        tokenAddress: "0xeabc4b91d9375796aa4f69cc764a4ab509080a58",
+        minCap: ethers.BigNumber.from(10).pow(18 + 2),
+        maxCap: ethers.BigNumber.from(10).pow(18 + 4),
+        depositConfigs: [
+          {
+            chainId: 43113,
+            minCap: ethers.BigNumber.from(10).pow(18 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(18 + 3)),
+          },
+          {
+            chainId: 5,
+            minCap: ethers.BigNumber.from(10).pow(18 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(18 + 3)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+      {
+        tokenAddress: "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+        minCap: ethers.BigNumber.from(10).pow(18 - 2),
+        maxCap: ethers.BigNumber.from(10).pow(18 + 2),
+        depositConfigs: [
+          {
+            chainId: 43113,
+            minCap: ethers.BigNumber.from(10).pow(18 - 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(97).mul(ethers.BigNumber.from(10).pow(18)),
+          },
+          {
+            chainId: 5,
+            minCap: ethers.BigNumber.from(10).pow(18 - 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(97).mul(ethers.BigNumber.from(10).pow(18)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+      {
+        tokenAddress: "0xdA5289fCAAF71d52a80A254da614a192b693e977",
+        minCap: ethers.BigNumber.from(10).pow(6 + 2),
+        maxCap: ethers.BigNumber.from(10).pow(6 + 4),
+        depositConfigs: [
+          {
+            chainId: 5,
+            minCap: ethers.BigNumber.from(10).pow(6 + 2),
+            // Max Cap needs to be less than the maxTransfer Fee on destination chain id to cover for incentive amount
+            maxCap: ethers.BigNumber.from(9).mul(ethers.BigNumber.from(10).pow(6 + 3)),
+          },
+        ],
+        equilibriumFee: 10000000,
+        maxFee: 200000000,
+        transferOverhead: 0,
+        excessStateTransferFeePer: parseUnits("0.045", 8),
+      },
+    ],
+  };
+  await deploy(config);
+})();

--- a/scripts/upgrades/upgrade-liquidity-farming.ts
+++ b/scripts/upgrades/upgrade-liquidity-farming.ts
@@ -1,0 +1,13 @@
+import { upgradeLiquidityFarming } from "./upgrade";
+import { verifyImplementation } from "../helpers";
+import { ethers } from "hardhat";
+
+(async () => {
+  const proxy = "0xBFAE64B3f3BBC05D466Adb5D5FAd8f520E61FAF8";
+  const [signer] = await ethers.getSigners();
+  console.log("Proxy: ", proxy, " Deployer: ", signer.address);
+  console.log("Upgrading Proxy...");
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await upgradeLiquidityFarming(proxy);
+  await verifyImplementation(proxy);
+})();

--- a/test/LiquidityFarmingV2.tests.ts
+++ b/test/LiquidityFarmingV2.tests.ts
@@ -1,0 +1,978 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+import {
+  ERC20Token,
+  LiquidityPool,
+  LiquidityProvidersTest,
+  WhitelistPeriodManager,
+  LPToken,
+  ExecutorManager,
+  TokenManager,
+  HyphenLiquidityFarming,
+  HyphenLiquidityFarmingV2,
+  // eslint-disable-next-line node/no-missing-import
+} from "../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { BigNumber, Signer } from "ethers";
+
+import { getLocaleString } from "./utils";
+
+const advanceTime = async (secondsToAdvance: number) => {
+  await ethers.provider.send("evm_increaseTime", [secondsToAdvance]);
+  await ethers.provider.send("evm_mine", []);
+};
+
+const getElapsedTime = async (callable: any): Promise<number> => {
+  const { timestamp: start } = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+  await callable();
+  const { timestamp: end } = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+  return end - start;
+};
+
+describe("LiquidityFarmingV2Tests", function () {
+  let owner: SignerWithAddress, pauser: SignerWithAddress, bob: SignerWithAddress;
+  let charlie: SignerWithAddress, tf: SignerWithAddress, executor: SignerWithAddress;
+  let token: ERC20Token, token2: ERC20Token;
+  let lpToken: LPToken;
+  let wlpm: WhitelistPeriodManager;
+  let liquidityProviders: LiquidityProvidersTest;
+  let liquidityPool: LiquidityPool;
+  let executorManager: ExecutorManager;
+  let tokenManager: TokenManager;
+  let farmingContract: HyphenLiquidityFarmingV2;
+  let trustedForwarder = "0xFD4973FeB2031D4409fB57afEE5dF2051b171104";
+  const NATIVE = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+  let BASE: BigNumber = BigNumber.from(10).pow(18);
+
+  const perWalletMaxCap = getLocaleString(1 * 1e18);
+  const tokenMaxCap = getLocaleString(1 * 1e18);
+
+  const perWalletNativeMaxCap = getLocaleString(1 * 1e18);
+  const tokenNativeMaxCap = getLocaleString(200 * 1e18);
+
+  beforeEach(async function () {
+    [owner, pauser, charlie, bob, tf, , executor] = await ethers.getSigners();
+
+    tokenManager = (await upgrades.deployProxy(await ethers.getContractFactory("TokenManager"), [
+      tf.address,
+      pauser.address,
+    ])) as TokenManager;
+    await tokenManager.deployed();
+
+    const erc20factory = await ethers.getContractFactory("ERC20Token");
+    token = (await upgrades.deployProxy(erc20factory, ["USDT", "USDT"])) as ERC20Token;
+    token2 = (await upgrades.deployProxy(erc20factory, ["USDC", "USDC"])) as ERC20Token;
+    for (const signer of [owner, bob, charlie]) {
+      await token.mint(signer.address, ethers.BigNumber.from(100000000).mul(ethers.BigNumber.from(10).pow(18)));
+      await token2.mint(signer.address, ethers.BigNumber.from(100000000).mul(ethers.BigNumber.from(10).pow(18)));
+    }
+    await tokenManager.addSupportedToken(token.address, BigNumber.from(1), BigNumber.from(10).pow(30), 0, 0, 0);
+    await tokenManager.addSupportedToken(token2.address, BigNumber.from(1), BigNumber.from(10).pow(30), 0, 0, 0);
+    await tokenManager.addSupportedToken(NATIVE, BigNumber.from(1), BigNumber.from(10).pow(30), 0, 0, 0);
+
+    const executorManagerFactory = await ethers.getContractFactory("ExecutorManager");
+    executorManager = (await executorManagerFactory.deploy()) as ExecutorManager;
+
+    const lpTokenFactory = await ethers.getContractFactory("LPToken");
+    lpToken = (await upgrades.deployProxy(lpTokenFactory, [
+      "LPToken",
+      "LPToken",
+      tf.address,
+      pauser.address,
+    ])) as LPToken;
+
+    const liquidtyProvidersFactory = await ethers.getContractFactory("LiquidityProvidersTest");
+    liquidityProviders = (await upgrades.deployProxy(liquidtyProvidersFactory, [
+      trustedForwarder,
+      lpToken.address,
+      tokenManager.address,
+      pauser.address,
+    ])) as LiquidityProvidersTest;
+    await liquidityProviders.deployed();
+    await lpToken.setLiquidityProviders(liquidityProviders.address);
+    await liquidityProviders.setLpToken(lpToken.address);
+
+    const wlpmFactory = await ethers.getContractFactory("WhitelistPeriodManager");
+    wlpm = (await upgrades.deployProxy(wlpmFactory, [
+      tf.address,
+      liquidityProviders.address,
+      tokenManager.address,
+      lpToken.address,
+      pauser.address,
+    ])) as WhitelistPeriodManager;
+    await wlpm.setLiquidityProviders(liquidityProviders.address);
+    await liquidityProviders.setWhiteListPeriodManager(wlpm.address);
+    await lpToken.setWhiteListPeriodManager(wlpm.address);
+    await wlpm.setCaps(
+      [token.address, token2.address, NATIVE],
+      [tokenMaxCap, tokenMaxCap, tokenNativeMaxCap],
+      [perWalletMaxCap, perWalletMaxCap, perWalletNativeMaxCap]
+    );
+    await wlpm.setAreWhiteListRestrictionsEnabled(true);
+
+    const lpFactory = await ethers.getContractFactory("LiquidityPool");
+    liquidityPool = (await upgrades.deployProxy(lpFactory, [
+      executorManager.address,
+      pauser.address,
+      tf.address,
+      tokenManager.address,
+      liquidityProviders.address,
+    ])) as LiquidityPool;
+    await liquidityProviders.setLiquidityPool(liquidityPool.address);
+
+    const farmingFactory = await ethers.getContractFactory("HyphenLiquidityFarmingV2");
+    farmingContract = (await upgrades.deployProxy(farmingFactory, [
+      tf.address,
+      pauser.address,
+      liquidityProviders.address,
+      lpToken.address,
+    ])) as HyphenLiquidityFarmingV2;
+    await wlpm.setIsExcludedAddressStatus([farmingContract.address], [true]);
+  });
+
+  describe("Deposit", async () => {
+    beforeEach(async function () {
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+
+      for (const signer of [owner, bob, charlie]) {
+        await lpToken.connect(signer).setApprovalForAll(farmingContract.address, true);
+        for (const tk of [token, token2]) {
+          await tk.connect(signer).approve(farmingContract.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(liquidityProviders.address, ethers.constants.MaxUint256);
+        }
+      }
+
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(charlie).addTokenLiquidity(token.address, 10);
+      await liquidityProviders.connect(charlie).addTokenLiquidity(token2.address, 10);
+    });
+
+    it("Should be able to deposit lp tokens", async function () {
+      await farmingContract.deposit(1, owner.address);
+      expect(await farmingContract.pendingToken(token.address, token2.address)).to.equal(0);
+      expect(await farmingContract.getNftIdsStaked(owner.address)).to.deep.equal([1].map(BigNumber.from));
+    });
+
+    it("Should be able to deposit lp tokens on behalf of another account", async function () {
+      await farmingContract.deposit(1, bob.address);
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(0);
+      expect(await farmingContract.getNftIdsStaked(bob.address)).to.deep.equal([1].map(BigNumber.from));
+      expect((await farmingContract.getNftIdsStaked(owner.address)).length).to.equal(0);
+    });
+
+    it("Should not be able to deposit LP token of un-initialized pools", async function () {
+      await expect(farmingContract.deposit(2, owner.address)).to.be.revertedWith("ERR__POOL_NOT_INITIALIZED");
+      expect(await farmingContract.getNftIdsStaked(owner.address)).to.deep.equal([]);
+    });
+
+    it("Should be able to accrue token rewards", async function () {
+      await farmingContract.deposit(1, owner.address);
+      const time = await getElapsedTime(async () => {
+        await advanceTime(100);
+      });
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(time * 10);
+    });
+
+    it("Should be able to create deposits in different tokens", async function () {
+      await farmingContract.setRewardPerSecond(token2.address, token.address, 10);
+      await farmingContract.deposit(1, owner.address);
+      const time = await getElapsedTime(async () => {
+        await advanceTime(100);
+        await farmingContract.deposit(2, owner.address);
+        await advanceTime(100);
+      });
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(time * 10);
+      expect(await farmingContract.pendingToken(2, token.address)).to.equal(1000);
+      expect(await farmingContract.getNftIdsStaked(owner.address)).to.deep.equal([1, 2].map(BigNumber.from));
+    });
+
+    it("Should be able to fetch correct nft index", async function () {
+      await farmingContract.setRewardPerSecond(token2.address, token.address, 10);
+      await farmingContract.deposit(1, owner.address);
+      await farmingContract.deposit(2, owner.address);
+      await farmingContract.connect(bob).deposit(3, bob.address);
+      await farmingContract.connect(bob).deposit(4, bob.address);
+      await farmingContract.connect(charlie).deposit(5, charlie.address);
+      await farmingContract.connect(charlie).deposit(6, charlie.address);
+
+      expect(await farmingContract.getStakedNftIndex(owner.address, 1)).to.equal(0);
+      expect(await farmingContract.getStakedNftIndex(owner.address, 2)).to.equal(1);
+      expect(await farmingContract.getStakedNftIndex(bob.address, 3)).to.equal(0);
+      expect(await farmingContract.getStakedNftIndex(bob.address, 4)).to.equal(1);
+      expect(await farmingContract.getStakedNftIndex(charlie.address, 5)).to.equal(0);
+      expect(await farmingContract.getStakedNftIndex(charlie.address, 6)).to.equal(1);
+
+      await expect(farmingContract.getStakedNftIndex(owner.address, 3)).to.be.revertedWith("ERR__NFT_NOT_STAKED");
+      await expect(farmingContract.getStakedNftIndex(bob.address, 1)).to.be.revertedWith("ERR__NFT_NOT_STAKED");
+      await expect(farmingContract.getStakedNftIndex(charlie.address, 4)).to.be.revertedWith("ERR__NFT_NOT_STAKED");
+    });
+  });
+
+  describe("Withdraw", async () => {
+    beforeEach(async function () {
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+
+      for (const signer of [owner, bob, charlie]) {
+        await lpToken.connect(signer).setApprovalForAll(farmingContract.address, true);
+        for (const tk of [token, token2]) {
+          await tk.connect(signer).approve(farmingContract.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(liquidityProviders.address, ethers.constants.MaxUint256);
+        }
+      }
+
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+    });
+
+    it("Should be able to withdraw nft", async function () {
+      await farmingContract.deposit(1, owner.address);
+      await token2.transfer(farmingContract.address, 10000000);
+      expect(await farmingContract.getNftIdsStaked(owner.address)).to.deep.equal([1].map(BigNumber.from));
+      await expect(farmingContract.withdraw(1, owner.address)).to.emit(farmingContract, "LogWithdraw");
+      expect(await lpToken.ownerOf(1)).to.equal(owner.address);
+    });
+
+    it("Should prevent non owner from withdrawing nft", async function () {
+      await farmingContract.deposit(1, bob.address);
+      await expect(farmingContract.connect(owner).withdraw(1, owner.address)).to.be.revertedWith("ERR__NFT_NOT_STAKED");
+      await expect(farmingContract.connect(bob).withdraw(2, bob.address)).to.be.revertedWith("ERR__NFT_NOT_STAKED");
+    });
+  });
+
+  describe("Rewards", async () => {
+    beforeEach(async function () {
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+      await farmingContract.setRewardPerSecond(token2.address, token.address, 15);
+
+      for (const signer of [owner, bob, charlie]) {
+        await lpToken.connect(signer).setApprovalForAll(farmingContract.address, true);
+        for (const tk of [token, token2]) {
+          await tk.connect(signer).approve(farmingContract.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(liquidityProviders.address, ethers.constants.MaxUint256);
+        }
+      }
+    });
+
+    it("Should prevent others from claiming rewards", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      expect((await farmingContract.pendingToken(1, token2.address)).toNumber()).to.be.greaterThan(0);
+      await expect(farmingContract.connect(bob).extractRewards(1, [token2.address], bob.address)).to.be.revertedWith(
+        "ERR__NOT_OWNER"
+      );
+    });
+
+    it("Should prevent others from withdrawing using v2", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 10);
+      await farmingContract.deposit(1, owner.address);
+      await farmingContract.connect(bob).deposit(2, bob.address);
+      await expect(farmingContract.connect(bob).withdrawAtIndex(1, bob.address, 0)).to.be.revertedWith(
+        "ERR__NOT_OWNER"
+      );
+    });
+
+    it("Should be able to calculate correct rewards correctly", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 30);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 30);
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      const time1 = await getElapsedTime(async () => {
+        await farmingContract.deposit(2, owner.address);
+      });
+      await advanceTime(300);
+      const time2 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(3, bob.address);
+      });
+      await advanceTime(500);
+      const time3 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(4, bob.address);
+      });
+      await advanceTime(900);
+
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(
+        Math.floor(10 * (100 + time1 + 300 + time2 + 500 / 4 + time3 / 4 + 900 / 4))
+      );
+      expect(await farmingContract.pendingToken(2, token.address)).to.equal(
+        Math.floor(15 * (300 + time2 + 500 + time3 + 900 / 4))
+      );
+      expect(await farmingContract.pendingToken(3, token2.address)).to.equal(
+        Math.floor(10 * ((500 * 3) / 4 + (time3 * 3) / 4 + (900 * 3) / 4))
+      );
+      expect(await farmingContract.pendingToken(4, token.address)).to.equal(Math.floor(15 * ((900 * 3) / 4)));
+    });
+
+    it("Should be able to calculate correct rewards correctly - 2", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 20);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 20);
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      const time1 = await getElapsedTime(async () => {
+        await farmingContract.deposit(2, owner.address);
+      });
+      await advanceTime(300);
+      const time2 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(3, bob.address);
+      });
+      await advanceTime(500);
+      const time3 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(4, bob.address);
+      });
+      await advanceTime(900);
+
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(
+        Math.floor(100 * 10 + time1 * 10 + 300 * 10 + time2 * 10 + (500 * 10) / 3 + (time3 * 10) / 3 + (900 * 10) / 3)
+      );
+      expect(await farmingContract.pendingToken(2, token.address)).to.equal(
+        Math.floor(15 * (300 + time2 + 500 + time3 + 900 / 3))
+      );
+      expect(await farmingContract.pendingToken(3, token2.address)).to.equal(
+        Math.floor((500 * 2 * 10) / 3 + (time3 * 2 * 10) / 3 + (900 * 2 * 10) / 3)
+      );
+      expect(await farmingContract.pendingToken(4, token.address)).to.equal(Math.floor(15 * ((900 * 2) / 3)));
+    });
+
+    it("Should be able to calculate correct rewards correctly - 3", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 60);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 60);
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      const time1 = await getElapsedTime(async () => {
+        await farmingContract.deposit(2, owner.address);
+      });
+      await advanceTime(300);
+      const time2 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(3, bob.address);
+      });
+      await advanceTime(500);
+      const time3 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(4, bob.address);
+      });
+      await advanceTime(900);
+
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(
+        Math.floor(100 * 10 + time1 * 10 + 300 * 10 + time2 * 10 + (500 * 10) / 7 + (time3 * 10) / 7 + (900 * 10) / 7)
+      );
+      expect(await farmingContract.pendingToken(2, token.address)).to.equal(
+        Math.floor(15 * (300 + time2 + 500 + time3 + 900 / 7))
+      );
+      expect(await farmingContract.pendingToken(3, token2.address)).to.equal(
+        Math.floor((500 * 6 * 10) / 7 + (time3 * 6 * 10) / 7 + (900 * 6 * 10) / 7)
+      );
+      expect(await farmingContract.pendingToken(4, token.address)).to.equal(Math.floor(15 * ((900 * 6) / 7)));
+    });
+
+    it("Should be able to send correct amount of rewards", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 60);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 60);
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      const time1 = await getElapsedTime(async () => {
+        await farmingContract.deposit(2, owner.address);
+      });
+      await advanceTime(300);
+      const time2 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(3, bob.address);
+      });
+      await advanceTime(500);
+      const time3 = await getElapsedTime(async () => {
+        await farmingContract.connect(bob).deposit(4, bob.address);
+      });
+      await advanceTime(900);
+
+      const expectedRewards = [
+        Math.floor(
+          100 * 10 +
+            time1 * 10 +
+            300 * 10 +
+            time2 * 10 +
+            (500 * 10) / 7 +
+            (time3 * 10) / 7 +
+            (900 * 10) / 7 +
+            (3 * 10) / 7
+        ),
+        Math.floor(15 * (300 + time2 + 500 + time3 + 900 / 7) + (4 * 15) / 7),
+        Math.floor((500 * 6 * 10) / 7 + (time3 * 6 * 10) / 7 + (900 * 6 * 10) / 7 + (5 * 6 * 10) / 7),
+        Math.floor(15 * ((900 * 6) / 7) + (6 * 15 * 6) / 7),
+      ];
+
+      await token.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+      await token2.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+
+      await expect(() => farmingContract.extractRewards(1, [token2.address], owner.address)).to.changeTokenBalances(
+        token2,
+        [farmingContract, owner],
+        [-expectedRewards[0], expectedRewards[0]]
+      );
+      await expect(() => farmingContract.extractRewards(2, [token.address], owner.address)).to.changeTokenBalances(
+        token,
+        [farmingContract, owner],
+        [-expectedRewards[1], expectedRewards[1]]
+      );
+      await expect(() =>
+        farmingContract.connect(bob).extractRewards(3, [token2.address], bob.address)
+      ).to.changeTokenBalances(token2, [farmingContract, bob], [-expectedRewards[2], expectedRewards[2]]);
+      await expect(() =>
+        farmingContract.connect(bob).extractRewards(4, [token.address], bob.address)
+      ).to.changeTokenBalances(token, [farmingContract, bob], [-expectedRewards[3], expectedRewards[3]]);
+
+      expect((await farmingContract.pendingToken(1, token2.address)).toNumber()).to.greaterThan(0);
+      expect((await farmingContract.pendingToken(2, token.address)).toNumber()).to.greaterThan(0);
+      expect((await farmingContract.pendingToken(3, token2.address)).toNumber()).to.greaterThan(0);
+      expect((await farmingContract.pendingToken(4, token.address)).toNumber()).to.equal(0);
+
+      expect((await farmingContract.nftInfo(1)).isStaked).to.be.true;
+      expect((await farmingContract.nftInfo(2)).isStaked).to.be.true;
+      expect((await farmingContract.nftInfo(3)).isStaked).to.be.true;
+      expect((await farmingContract.nftInfo(4)).isStaked).to.be.true;
+    });
+
+    it("Extraction of Rewards on 1 token should not affect the other", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+
+      await token2.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      await farmingContract.deposit(2, owner.address);
+      await advanceTime(100);
+      await farmingContract.withdraw(2, owner.address);
+
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(
+        Math.floor(100 * 10 + 1 * 10 + (100 * 10) / 2 + (1 * 10) / 2)
+      );
+      expect((await farmingContract.nftInfo(1)).isStaked).to.be.true;
+    });
+
+    it("Should be able to send correct amount of rewards to delegatee while withdrawing lp token immediately if available", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+
+      await token2.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      await expect(() => farmingContract.withdraw(1, bob.address)).to.changeTokenBalances(
+        token2,
+        [farmingContract, bob],
+        [-1010, 1010]
+      );
+    });
+
+    it("Should be able to send correct amount of rewards while withdrawing", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 60);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 60);
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      const time1 = 1;
+      await farmingContract.deposit(2, owner.address);
+      await advanceTime(300);
+      const time2 = 1;
+      await farmingContract.connect(bob).deposit(3, bob.address);
+
+      await advanceTime(500);
+      const time3 = 1;
+      await farmingContract.connect(bob).deposit(4, bob.address);
+      await advanceTime(900);
+
+      const expectedRewards = [
+        Math.floor(
+          100 * 10 +
+            time1 * 10 +
+            300 * 10 +
+            time2 * 10 +
+            (500 * 10) / 7 +
+            (time3 * 10) / 7 +
+            (900 * 10) / 7 +
+            (3 * 10) / 7
+        ),
+        Math.floor(15 * (300 + time2 + 500 + time3 + 900 / 7) + (4 * 15) / 7),
+        Math.floor((500 * 6 * 10 + time3 * 6 * 10 + 900 * 6 * 10 + 3 * 6 * 10 + 2 * 7 * 10) / 7),
+        Math.floor(15 * ((900 * 6) / 7) + (4 * 15 * 6) / 7 + 2 * 15),
+      ];
+
+      await token.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+      await token2.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+
+      await expect(() => farmingContract.withdraw(1, owner.address)).to.changeTokenBalances(
+        token2,
+        [farmingContract, owner],
+        [-expectedRewards[0], expectedRewards[0]]
+      );
+      await expect(() => farmingContract.withdraw(2, owner.address)).to.changeTokenBalances(
+        token,
+        [farmingContract, owner],
+        [-expectedRewards[1], expectedRewards[1]]
+      );
+      await expect(() => farmingContract.connect(bob).withdraw(3, bob.address)).to.changeTokenBalances(
+        token2,
+        [farmingContract, bob],
+        [-expectedRewards[2], expectedRewards[2]]
+      );
+      await expect(() => farmingContract.connect(bob).withdraw(4, bob.address)).to.changeTokenBalances(
+        token,
+        [farmingContract, bob],
+        [-expectedRewards[3], expectedRewards[3]]
+      );
+
+      expect(await lpToken.ownerOf(1)).to.equal(owner.address);
+      expect(await lpToken.ownerOf(2)).to.equal(owner.address);
+      expect(await lpToken.ownerOf(3)).to.equal(bob.address);
+      expect(await lpToken.ownerOf(4)).to.equal(bob.address);
+
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(0);
+      expect(await farmingContract.pendingToken(2, token.address)).to.equal(0);
+      expect(await farmingContract.pendingToken(3, token2.address)).to.equal(0);
+      expect(await farmingContract.pendingToken(4, token.address)).to.equal(0);
+
+      expect((await farmingContract.nftInfo(1)).isStaked).to.be.false;
+      expect((await farmingContract.nftInfo(2)).isStaked).to.be.false;
+      expect((await farmingContract.nftInfo(3)).isStaked).to.be.false;
+      expect((await farmingContract.nftInfo(4)).isStaked).to.be.false;
+    });
+
+    it("Should be able to withdrawing using withdraw v2", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 60);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 60);
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      const time1 = 1;
+      await farmingContract.deposit(2, owner.address);
+      await advanceTime(300);
+      const time2 = 1;
+      await farmingContract.connect(bob).deposit(3, bob.address);
+
+      await advanceTime(500);
+      const time3 = 1;
+      await farmingContract.connect(bob).deposit(4, bob.address);
+      await advanceTime(900);
+
+      const expectedRewards = [
+        Math.floor(
+          100 * 10 +
+            time1 * 10 +
+            300 * 10 +
+            time2 * 10 +
+            (500 * 10) / 7 +
+            (time3 * 10) / 7 +
+            (900 * 10) / 7 +
+            (3 * 10) / 7
+        ),
+        Math.floor(15 * (300 + time2 + 500 + time3 + 900 / 7) + (4 * 15) / 7),
+        Math.floor((500 * 6 * 10 + time3 * 6 * 10 + 900 * 6 * 10 + 3 * 6 * 10 + 2 * 7 * 10) / 7),
+        Math.floor(15 * ((900 * 6) / 7) + (4 * 15 * 6) / 7 + 2 * 15),
+      ];
+
+      await token.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+      await token2.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+
+      let index = await farmingContract.getStakedNftIndex(owner.address, 1);
+      await expect(() => farmingContract.withdrawAtIndex(1, owner.address, index)).to.changeTokenBalances(
+        token2,
+        [farmingContract, owner],
+        [-expectedRewards[0], expectedRewards[0]]
+      );
+      index = await farmingContract.getStakedNftIndex(owner.address, 2);
+      await expect(() => farmingContract.withdrawAtIndex(2, owner.address, index)).to.changeTokenBalances(
+        token,
+        [farmingContract, owner],
+        [-expectedRewards[1], expectedRewards[1]]
+      );
+      index = await farmingContract.getStakedNftIndex(bob.address, 3);
+      await expect(() => farmingContract.connect(bob).withdrawAtIndex(3, bob.address, index)).to.changeTokenBalances(
+        token2,
+        [farmingContract, bob],
+        [-expectedRewards[2], expectedRewards[2]]
+      );
+      index = await farmingContract.getStakedNftIndex(bob.address, 4);
+      await expect(() => farmingContract.connect(bob).withdrawAtIndex(4, bob.address, index)).to.changeTokenBalances(
+        token,
+        [farmingContract, bob],
+        [-expectedRewards[3], expectedRewards[3]]
+      );
+
+      expect(await lpToken.ownerOf(1)).to.equal(owner.address);
+      expect(await lpToken.ownerOf(2)).to.equal(owner.address);
+      expect(await lpToken.ownerOf(3)).to.equal(bob.address);
+      expect(await lpToken.ownerOf(4)).to.equal(bob.address);
+
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(0);
+      expect(await farmingContract.pendingToken(2, token.address)).to.equal(0);
+      expect(await farmingContract.pendingToken(3, token2.address)).to.equal(0);
+      expect(await farmingContract.pendingToken(4, token.address)).to.equal(0);
+
+      expect((await farmingContract.nftInfo(1)).isStaked).to.be.false;
+      expect((await farmingContract.nftInfo(2)).isStaked).to.be.false;
+      expect((await farmingContract.nftInfo(3)).isStaked).to.be.false;
+      expect((await farmingContract.nftInfo(4)).isStaked).to.be.false;
+    });
+
+    it("Should be able to send correct amount of rewards while withdrawing lp token immediately if available", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+
+      await token2.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      await expect(() => farmingContract.withdraw(1, owner.address)).to.changeTokenBalances(
+        token2,
+        [farmingContract, owner],
+        [-1010, 1010]
+      );
+    });
+
+    it("Should be able to send correct amount to delegatee of rewards while withdrawing lp token immediately if available", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+
+      await token2.transfer(farmingContract.address, ethers.BigNumber.from(10).pow(18));
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      await expect(() => farmingContract.withdraw(1, bob.address)).to.changeTokenBalances(
+        token2,
+        [farmingContract, bob],
+        [-1010, 1010]
+      );
+
+      expect(await lpToken.ownerOf(1)).to.equal(owner.address);
+    });
+  });
+
+  describe("Rewards - NATIVE", async () => {
+    beforeEach(async function () {
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 10);
+      await farmingContract.setRewardPerSecond(token2.address, NATIVE, 15);
+
+      for (const signer of [owner, bob, charlie]) {
+        await lpToken.connect(signer).setApprovalForAll(farmingContract.address, true);
+        for (const tk of [token, token2]) {
+          await tk.connect(signer).approve(farmingContract.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(liquidityProviders.address, ethers.constants.MaxUint256);
+        }
+      }
+    });
+
+    it("Should be able to send correct amount of rewards", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.addTokenLiquidity(token2.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 60);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token2.address, 60);
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      await farmingContract.deposit(2, owner.address);
+      await advanceTime(300);
+      await farmingContract.connect(bob).deposit(3, bob.address);
+      await advanceTime(500);
+      await farmingContract.connect(bob).deposit(4, bob.address);
+      await advanceTime(900);
+
+      const expectedRewards = [
+        Math.floor(
+          100 * 10 + 1 * 10 + 300 * 10 + 1 * 10 + (500 * 10) / 7 + (1 * 10) / 7 + (900 * 10) / 7 + (2 * 10) / 7
+        ),
+        Math.floor(15 * (300 + 1 + 500 + 1 + (900 + 3) / 7)),
+        Math.floor((500 * 6 * 10 + 1 * 6 * 10 + 900 * 6 * 10 + 2 * 6 * 10 + 2 * 7 * 10) / 7),
+        Math.floor(15 * ((900 * 6) / 7) + (3 * 15 * 6) / 7 + 2 * 15),
+      ];
+
+      await owner.sendTransaction({
+        to: farmingContract.address,
+        value: ethers.BigNumber.from(10).pow(18),
+      });
+
+      await expect(() => farmingContract.withdraw(1, owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-expectedRewards[0], expectedRewards[0]]
+      );
+      await expect(() => farmingContract.withdraw(2, owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-expectedRewards[1], expectedRewards[1]]
+      );
+      await expect(() => farmingContract.connect(bob).withdraw(3, bob.address)).to.changeEtherBalances(
+        [farmingContract, bob],
+        [-expectedRewards[2], expectedRewards[2]]
+      );
+      await expect(() => farmingContract.connect(bob).withdraw(4, bob.address)).to.changeEtherBalances(
+        [farmingContract, bob],
+        [-expectedRewards[3], expectedRewards[3]]
+      );
+    });
+  });
+
+  describe("Reward Rate updation", async () => {
+    beforeEach(async () => {
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 10);
+      await farmingContract.setRewardPerSecond(token2.address, NATIVE, 15);
+
+      for (const signer of [owner, bob, charlie]) {
+        for (const tk of [token, token2]) {
+          await tk.connect(signer).approve(farmingContract.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(liquidityProviders.address, ethers.constants.MaxUint256);
+        }
+      }
+    });
+
+    it("Should not invalidate pending rewards on reward rate updation", async function () {
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await liquidityProviders.connect(bob).addTokenLiquidity(token.address, 10);
+      await liquidityProviders.connect(charlie).addTokenLiquidity(token.address, 20);
+
+      await lpToken.approve(farmingContract.address, 1);
+      await lpToken.connect(bob).approve(farmingContract.address, 2);
+      await lpToken.connect(charlie).approve(farmingContract.address, 3);
+
+      let rewardOwner = 0,
+        rewardBob = 0,
+        rewardCharlie = 0;
+
+      await owner.sendTransaction({ to: farmingContract.address, value: ethers.BigNumber.from(10).pow(18) });
+
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += 10 * 100));
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 20);
+      await advanceTime(100);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += 10 * 1 + 20 * 100));
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 16);
+      await advanceTime(100);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += 20 * 1 + 16 * 100));
+
+      await farmingContract.connect(bob).deposit(2, bob.address);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += 16));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal(rewardBob);
+      await advanceTime(150);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += (16 * 150) / 2));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal((rewardBob += (16 * 150) / 2));
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 0);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += 16 / 2));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal((rewardBob += 16 / 2));
+      await advanceTime(1000);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal(rewardOwner);
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal(rewardBob);
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 100);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal(rewardOwner);
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal(rewardBob);
+      await advanceTime(500);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += (100 * 500) / 2));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal((rewardBob += (100 * 500) / 2));
+
+      await farmingContract.connect(charlie).deposit(3, charlie.address);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += 100 / 2));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal((rewardBob += 100 / 2));
+      expect(await farmingContract.pendingToken(3, NATIVE)).to.equal(rewardCharlie);
+      await advanceTime(500);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += (100 * 500) / 4));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal((rewardBob += (100 * 500) / 4));
+      expect(await farmingContract.pendingToken(3, NATIVE)).to.equal((rewardCharlie += (100 * 500) / 2));
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 600);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += 100 / 4));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal((rewardBob += 100 / 4));
+      expect(await farmingContract.pendingToken(3, NATIVE)).to.equal((rewardCharlie += 100 / 2));
+      await advanceTime(600);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal((rewardOwner += (600 * 600) / 4));
+      expect(await farmingContract.pendingToken(2, NATIVE)).to.equal((rewardBob += (600 * 600) / 4));
+      expect(await farmingContract.pendingToken(3, NATIVE)).to.equal((rewardCharlie += (600 * 600) / 2));
+
+      await expect(() => farmingContract.extractRewards(1, [NATIVE], owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-(rewardOwner + 600 / 4), rewardOwner + 600 / 4]
+      );
+      rewardOwner = 0;
+      rewardBob += 600 / 4;
+      rewardCharlie += 600 / 2;
+      await expect(() => farmingContract.connect(bob).withdraw(2, bob.address)).to.changeEtherBalances(
+        [farmingContract, bob],
+        [-(rewardBob + 600 / 4), rewardBob + 600 / 4]
+      );
+      rewardOwner += 600 / 4;
+      rewardCharlie += (600 * 2) / 4;
+      await expect(() => farmingContract.connect(charlie).withdraw(3, charlie.address)).to.changeEtherBalances(
+        [farmingContract, charlie],
+        [-(rewardCharlie + (600 * 2) / 3), rewardCharlie + (600 * 2) / 3]
+      );
+      rewardOwner += 600 / 3;
+      await expect(() => farmingContract.extractRewards(1, [NATIVE], owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-(rewardOwner + 600), rewardOwner + 600]
+      );
+    });
+  });
+
+  describe("Multi Token Rewards", async function () {
+    beforeEach(async () => {
+      for (const signer of [owner, bob, charlie]) {
+        for (const tk of [token, token2]) {
+          await tk.connect(signer).approve(farmingContract.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(liquidityProviders.address, ethers.constants.MaxUint256);
+        }
+      }
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await lpToken.setApprovalForAll(farmingContract.address, true);
+    });
+
+    it("Should set rewards in multiple tokens correctly", async function () {
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+      expect(await farmingContract.getRewardTokens(token.address)).to.deep.equal([token2.address]);
+      expect(await farmingContract.getRewardRatePerSecond(token.address, token2.address)).to.equal(10);
+      expect(await farmingContract.getRewardRatePerSecond(token.address, NATIVE)).to.equal(0);
+
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 20);
+      expect(await farmingContract.getRewardTokens(token.address)).to.deep.equal([token2.address, NATIVE]);
+      expect(await farmingContract.getRewardRatePerSecond(token.address, token2.address)).to.equal(10);
+      expect(await farmingContract.getRewardRatePerSecond(token.address, NATIVE)).to.equal(20);
+    });
+
+    it("Should calculate rewards in multiple tokens correctly", async function () {
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 20);
+      await farmingContract.deposit(1, owner.address);
+      await advanceTime(100);
+      expect(await farmingContract.pendingToken(1, token.address)).to.equal(0);
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(10 * 100);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal(20 * 100);
+    });
+
+    it("Should extract rewards in multiple tokens correctly", async function () {
+      await token2.transfer(farmingContract.address, 10000000);
+      await owner.sendTransaction({ to: farmingContract.address, value: 1000000 });
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 20);
+      await farmingContract.deposit(1, owner.address);
+
+      await advanceTime(100);
+      await expect(() => farmingContract.extractRewards(1, [token2.address], owner.address)).to.changeTokenBalances(
+        token2,
+        [farmingContract, owner],
+        [-(10 * 101), 10 * 101]
+      );
+      await expect(() => farmingContract.extractRewards(1, [NATIVE], owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-(20 * 102), 20 * 102]
+      );
+      await advanceTime(100);
+      const token2Balance = await token2.balanceOf(owner.address);
+      await expect(() =>
+        farmingContract.extractRewards(1, [NATIVE, token2.address], owner.address)
+      ).to.changeEtherBalances([farmingContract, owner], [-(20 * 101), 20 * 101]);
+      expect(await token2.balanceOf(owner.address)).to.equal(token2Balance.add(10 * 102));
+    });
+
+    it("Should extract rewards in all tokens when withdrawing NFT", async function () {
+      await token2.transfer(farmingContract.address, 10000000);
+      await owner.sendTransaction({ to: farmingContract.address, value: 1000000 });
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 20);
+      await farmingContract.deposit(1, owner.address);
+
+      await advanceTime(100);
+      const token2Balance = await token2.balanceOf(owner.address);
+      await expect(() => farmingContract.withdraw(1, owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-(20 * 101), 20 * 101]
+      );
+      expect(await token2.balanceOf(owner.address)).to.equal(token2Balance.add(10 * 101));
+    });
+
+    it("Should be able to claim rewards in token added after staking", async function () {
+      await token2.transfer(farmingContract.address, 10000000);
+      await owner.sendTransaction({ to: farmingContract.address, value: 1000000 });
+
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+      await farmingContract.deposit(1, owner.address);
+
+      await advanceTime(100);
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(100 * 10);
+
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 20);
+      await advanceTime(200);
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(301 * 10);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal(200 * 20);
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 0);
+
+      await advanceTime(500);
+      expect(await farmingContract.pendingToken(1, token2.address)).to.equal(302 * 10);
+      expect(await farmingContract.pendingToken(1, NATIVE)).to.equal(701 * 20);
+
+      const token2Balance = await token2.balanceOf(owner.address);
+      await expect(() => farmingContract.withdraw(1, owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-(20 * 702), 20 * 702]
+      );
+      expect(await token2.balanceOf(owner.address)).to.equal(token2Balance.add(10 * 302));
+    });
+  });
+
+  describe("Migration", async function () {
+    let farmingContractV1: HyphenLiquidityFarming;
+    beforeEach(async () => {
+      farmingContractV1 = (await upgrades.deployProxy(await ethers.getContractFactory("HyphenLiquidityFarming"), [
+        tf.address,
+        pauser.address,
+        liquidityProviders.address,
+        lpToken.address,
+      ])) as HyphenLiquidityFarming;
+      await wlpm.setIsExcludedAddressStatus([farmingContract.address], [true]);
+
+      for (const signer of [owner, bob, charlie]) {
+        for (const tk of [token, token2]) {
+          await tk.connect(signer).approve(farmingContract.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(farmingContractV1.address, ethers.constants.MaxUint256);
+          await tk.connect(signer).approve(liquidityProviders.address, ethers.constants.MaxUint256);
+        }
+      }
+      await liquidityProviders.addTokenLiquidity(token.address, 10);
+      await lpToken.setApprovalForAll(farmingContract.address, true);
+      await lpToken.setApprovalForAll(farmingContractV1.address, true);
+    });
+
+    it("Should migrate NFT from V1 to V2", async function () {
+      await token2.transfer(farmingContractV1.address, 10000000);
+      await token2.transfer(farmingContract.address, 10000000);
+      await owner.sendTransaction({ to: farmingContract.address, value: 1000000 });
+
+      await farmingContractV1.initalizeRewardPool(token.address, token2.address, 10);
+      await farmingContract.setRewardPerSecond(token.address, token2.address, 10);
+      await farmingContract.setRewardPerSecond(token.address, NATIVE, 20);
+      await farmingContractV1.deposit(1, owner.address);
+      await advanceTime(100);
+
+      await expect(() => farmingContractV1.migrateNftsToV2([1], farmingContract.address)).to.changeTokenBalances(
+        token2,
+        [farmingContractV1, owner],
+        [-(10 * 101), 10 * 101]
+      );
+
+      await advanceTime(100);
+      const token2Balance = await token2.balanceOf(owner.address);
+      await expect(() => farmingContract.withdraw(1, owner.address)).to.changeEtherBalances(
+        [farmingContract, owner],
+        [-(20 * 101), 20 * 101]
+      );
+      expect(await token2.balanceOf(owner.address)).to.equal(token2Balance.add(10 * 101));
+    });
+  });
+});


### PR DESCRIPTION
- Implement `migrateNftsToV2` in LiquidityFarming to allow users to migrate their NFTs to V2 contract.
- Implement LiquidityFarmingV2 to introduce support for giving rewards in multiple tokens simultaneously.